### PR TITLE
[Index] Add parser support for cogs without the author field

### DIFF
--- a/index/parser.py
+++ b/index/parser.py
@@ -86,10 +86,14 @@ class Cog:
             description = self.description
         else:
             description = self.short
+        if self.author:
+            author = ', '.join(self.author)
+        else:
+            author = self.repo.name
         em = discord.Embed(url=url, description=description, colour=discord.Colour.red())
         em.set_author(name=f"{self.name} from {self.repo.name}")
         em.add_field(name="Type", value=self.repo.rx_category, inline=True)
-        em.add_field(name="Author", value=f"{', '.join(self.author)}", inline=True)
+        em.add_field(name="Author", value=author, inline=True)
         if self.requirements:
             em.add_field(name="External libraries", value=f"{', '.join(self.requirements)}", inline=True)
         if self.required_cogs:


### PR DESCRIPTION
Some cogs may not have an `author` field (for whatever reason), so it would be nice to handle any invalid form body errors. I was curious as to how to handle this and I'd love to see your opinion on the changes.

Edit: This has been tested