### PR TITLE
[Defender] WD: Strip yml codeblocks

### DIFF
--- a/defender/commands/stafftools.py
+++ b/defender/commands/stafftools.py
@@ -317,6 +317,8 @@ class StaffTools(MixinMeta, metaclass=CompositeMetaClass): # type: ignore
         prompts_sent = False
         if rule.startswith("```yaml"):
             rule = rule.lstrip("```yaml")
+        if rule.startswith("```yml"):
+            rule = rule.lstrip("```yml")
         if rule.startswith("```") or rule.endswith("```"):
             rule = rule.strip("```")
 


### PR DESCRIPTION
`[p]defender warden add` wouldn't strip yaml codeblocks correctly if the shortcut `yml` lang was used.