### PR TITLE
Defender: Toggle Message Deletion in Comment-Analysis

### DIFF
--- a/defender/commands/settings.py
+++ b/defender/commands/settings.py
@@ -699,6 +699,15 @@ class Settings(MixinMeta, metaclass=CompositeMetaClass):  # type: ignore
         await ctx.send(f"Value set. I will delete {days} days worth "
                        "of messages if the action is ban.")
 
+    @caset.command(name="delmsg")
+    async def casetdelmsg(self, ctx: commands.Context):
+        """Sets whether a CA Event will delete the message"""
+        delmsg = await self.config.guild(ctx.guild).ca_delete_message_on_trigger()
+        await self.config.guild(ctx.guild).ca_delete_message_on_trigger.set(not delmsg)
+        delmsg = await self.config.guild(ctx.guild).ca_delete_message_on_trigger()
+        await ctx.send(f"Value set.  Delete Message After Event is now {delmsg}")
+
+
     @dset.group(name="voteout")
     @commands.admin()
     async def voteoutgroup(self, ctx: commands.Context):

--- a/defender/core/automodules.py
+++ b/defender/core/automodules.py
@@ -397,11 +397,17 @@ class AutoModules(MixinMeta, metaclass=CompositeMetaClass): # type: ignore
         elif action == Action.NoAction:
             heat_key = f"core-ca-{author.id}-{message.channel.id}-{len(message.content)}"
 
-        await self.send_notification(guild, text, title=EMBED_TITLE, fields=EMBED_FIELDS, jump_to=message, heat_key=heat_key,
-                                     no_repeat_for=timedelta(minutes=1), quick_action=QuickAction(author.id, reason))
+        ca_msg = await self.send_notification(guild, text, title=EMBED_TITLE, fields=EMBED_FIELDS, jump_to=message, heat_key=heat_key,
+                                              no_repeat_for=timedelta(minutes=1), quick_action=QuickAction(author.id, reason))
 
-        with contextlib.suppress(discord.HTTPException, discord.Forbidden):
-            await message.delete()
+        emoji = '\U00002049' + '\U0000FE0F'
+        await ca_msg.add_reaction(emoji)
+        # await message.channel.send(f'DEBUG: {results}')
+        ca_delete_message_on_trigger = await self.config.guild(guild).ca_delete_message_on_trigger()
+
+        if ca_delete_message_on_trigger:
+            with contextlib.suppress(discord.HTTPException, discord.Forbidden):
+                await message.delete()
 
         await self.create_modlog_case(
             self.bot,
@@ -414,3 +420,4 @@ class AutoModules(MixinMeta, metaclass=CompositeMetaClass): # type: ignore
             until=None,
             channel=None,
         )
+

--- a/defender/core/status.py
+++ b/defender/core/status.py
@@ -161,6 +161,7 @@ async def make_status(ctx, cog):
     if d_enabled:
         enabled = await cog.config.guild(guild).raider_detection_enabled()
 
+    delmsg = await cog.config.guild(guild).ca_delete_message_on_trigger()
     rank = await cog.config.guild(guild).raider_detection_rank()
     messages = await cog.config.guild(guild).raider_detection_messages()
     minutes = await cog.config.guild(guild).raider_detection_minutes()
@@ -267,7 +268,10 @@ async def make_status(ctx, cog):
     if ca_action == Action.Ban:
         ca_action = f"**ban** the author and **delete {ca_wipe} days** worth of messages"
     elif ca_action == Action.NoAction:
-        ca_action = "**delete** it and **notify** the staff"
+        if delmsg:
+            ca_action = f"**delete** it and **notify** the staff"
+        else:
+            ca_action = f"**NOT delete** it and **notify** the staff"
     else:
         ca_action = f"**{ca_action.value}** the author"
 

--- a/defender/defender.py
+++ b/defender/defender.py
@@ -81,6 +81,7 @@ default_guild_settings = {
     "ca_rank": Rank.Rank3.value,
     "ca_reason": "Bad comment", # Mod-log reason
     "ca_wipe": 0, # If action is ban, wipe X days worth of messages
+    "ca_delete_message_on_trigger": True, # If CA Triggers, Delete the Message
     "alert_enabled": True, # Available to helper roles by default
     "silence_enabled": False, # This is a manual module. Enabled = Available to be used...
     "silence_rank": 0, # ... and as such, this default will be 0


### PR DESCRIPTION
Allows for Comment-Analysis (CA) Events to not delete the message
in question, while still Alerting the staff as normal.

- Adds guild config `ca_delete_message_on_trigger` as `True` by default.
- Adds `dset commentanalysis delmsg` to Toggle True/False
- Adds `def status` CA-delmsg awareness
 

Signed-off-by: Donald Hoskins <grommish@gmail.com>