### PR TITLE
[Defender] Ensure timestamps are in UTC

### DIFF
--- a/defender/core/utils.py
+++ b/defender/core/utils.py
@@ -74,8 +74,11 @@ def utcnow():
     else:
         return datetime.datetime.utcnow()
 
-def timestamp(datetime: datetime.datetime, relative=False):
+def timestamp(ts: datetime.datetime, relative=False):
+    # Discord assumes UTC timestamps
+    timestamp = int(ts.replace(tzinfo=datetime.timezone.utc).timestamp())
+
     if relative:
-        return f"<t:{int(datetime.timestamp())}:R>"
+        return f"<t:{timestamp}:R>"
     else:
-        return f"<t:{int(datetime.timestamp())}>"
+        return f"<t:{timestamp}>"


### PR DESCRIPTION
This PR fixes non-timezone aware timestamps. In dpy 1.x, timestamps are not timezone aware. When we convert the timestamp to a Discord timestamp, the timestamp is in the local timezone, but Discord expects it in UTC. We should convert the time object to UTC first, and then convert it to a UNIX timestamp.

In dpy 2.x, timestamps from `discord` objects are now timezone aware, so this should be a no-op (that being said, I have not tried with dpy2 yet).

I replaced the `datetime` arg with `ts` instead in order to avoid collision with the `datetime` module while accessing `timezone`.

Before (my timezone is GMT-7 Pacific):
![Screenshot from 2022-05-08 23-43-03](https://user-images.githubusercontent.com/6710854/167356643-c6d329e6-d059-43c3-9344-1528b4c9d5d2.png)


After:
![Screenshot from 2022-05-08 23-37-59](https://user-images.githubusercontent.com/6710854/167356571-78f6c4b4-4720-43e2-8fc6-0a8ee469f014.png)

