### PR TITLE
[Defender] Await `Bot.add_cog` call

### DIFF
--- a/defender/__init__.py
+++ b/defender/__init__.py
@@ -6,5 +6,5 @@ with open(Path(__file__).parent / "info.json") as fp:
     __red_end_user_data_statement__ = json.load(fp)["end_user_data_statement"]
 
 
-def setup(bot):
-    bot.add_cog(Defender(bot))
+async def setup(bot):
+    await bot.add_cog(Defender(bot))


### PR DESCRIPTION
Since `discord.py` v2's `Bot.add_cog()` is a coroutine, this commit makes `setup` async and await the said coroutine. Without it, Red will complain like this:
```
[HH:MM:SS] WARNING  [py.warnings] /path/to/Red-DiscordBot/data/Bot.Instance/cogs/CogManager/cogs/defender/__init__.py:10: RuntimeWarning: coroutine 'Red.add_cog' was never awaited
  bot.add_cog(Defender(bot))
```

Reference: https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.Bot.add_cog