### PR TITLE
[Defender] Add fuzzywuzzy to requirements

### DIFF
--- a/defender/info.json
+++ b/defender/info.json
@@ -11,7 +11,7 @@
         "moderation",
         "monitoring"
     ],
-    "requirements": ["pyyaml~=5.4.1", "emoji~=1.6.3", "pydantic~=1.9.1", "regex==2022.4.24"],
+    "requirements": ["pyyaml~=5.4.1", "emoji~=1.6.3", "pydantic~=1.9.1", "regex==2022.4.24", "fuzzywuzzy==0.18.0"],
     "min_bot_version": "3.5.0.dev317",
     "type": "COG",
     "end_user_data_statement": "This cog stores user IDs for the purpose of counting the messages a user sends and/or send the DM notifications the user has subscribed to."


### PR DESCRIPTION
On a fresh install of the `defender` cog, it fails to load because it is missing the fuzzywuzzy dependency.

This PR will add it to the requirements in `info.json` so that it will also be installed when the cog is installed, allowing the cog to be loaded without issue.