### PR TITLE
[Defender] Add threads actions in Warden rules.

### DIFF
--- a/defender/core/warden/enums.py
+++ b/defender/core/warden/enums.py
@@ -60,6 +60,10 @@ class Action(enum.Enum):
     DeleteLastMessageSentAfter = "delete-last-message-sent-after"
     SendMessage = "send-message" # Send a message to an arbitrary destination with an optional embed
     GetUserInfo = "get-user-info" # Get info of an arbitrary user
+    ArchiveThread = "archive-thread" # Close the thread in context
+    LockThread = "lock-thread" # Lock the thread in context
+    ArchiveAndLockThread = "archive-and-lock-thread" # Close and lock the thread in context
+    DeleteThread = "delete-thread" # Delete the thread in context
     Exit = "exit" # Stops processing the rule
     WarnSystemWarn = "warnsystem-warn" ## Warnsystem integration
     VarAssign = "var-assign" # Assigns a string to a variable

--- a/defender/core/warden/enums.py
+++ b/defender/core/warden/enums.py
@@ -60,9 +60,9 @@ class Action(enum.Enum):
     DeleteLastMessageSentAfter = "delete-last-message-sent-after"
     SendMessage = "send-message" # Send a message to an arbitrary destination with an optional embed
     GetUserInfo = "get-user-info" # Get info of an arbitrary user
-    ArchiveThread = "archive-thread" # Close the thread in context
+    ArchiveThread = "archive-thread" # Archive the thread in context
     LockThread = "lock-thread" # Lock the thread in context
-    ArchiveAndLockThread = "archive-and-lock-thread" # Close and lock the thread in context
+    ArchiveAndLockThread = "archive-and-lock-thread" # Archive and lock the thread in context
     DeleteThread = "delete-thread" # Delete the thread in context
     Exit = "exit" # Stops processing the rule
     WarnSystemWarn = "warnsystem-warn" ## Warnsystem integration

--- a/defender/core/warden/rule.py
+++ b/defender/core/warden/rule.py
@@ -1309,6 +1309,26 @@ class WardenRule:
                     raise ExecutionError(f"[Warden] ({self.name}): Failed to edit message. "
                                         f"{params.edit_message_id} is not a valid ID")
 
+        @processor(Action.ArchiveThread)
+        async def archive_thread(params: models.IsNone):
+            if isinstance(channel, discord.Thread):
+                await channel.edit(archived=True, reason=f"Archived by Warden rule '{self.name}'")
+
+        @processor(Action.LockThread)
+        async def lock_thread(params: models.IsNone):
+            if isinstance(channel, discord.Thread):
+                await channel.edit(locked=True, reason=f"Locked by Warden rule '{self.name}'")
+
+        @processor(Action.ArchiveAndLockThread)
+        async def archive_and_lock_thread(params: models.IsNone):
+            if isinstance(channel, discord.Thread):
+                await channel.edit(archived=True, locked=True, reason=f"Archived and locked by Warden rule '{self.name}'")
+
+        @processor(Action.DeleteThread)
+        async def delete_thread(params: models.IsNone):
+            if isinstance(channel, discord.Thread):
+                await channel.delete()
+
         @processor(Action.GetUserInfo)
         async def get_user_info(params: models.GetUserInfo):
             _id = safe_sub(params.id)

--- a/defender/core/warden/validation.py
+++ b/defender/core/warden/validation.py
@@ -491,6 +491,10 @@ ACTIONS_VALIDATORS = {
     Action.DeleteLastMessageSentAfter: IsDeleteLastMessageSentAfterTimeDelta,
     Action.SendMessage: SendMessage,
     Action.GetUserInfo: GetUserInfo,
+    Action.ArchiveThread: IsNone,
+    Action.LockThread: IsNone,
+    Action.ArchiveAndLockThread: IsNone,
+    Action.DeleteThread: IsNone,
     Action.Exit: IsNone,
     Action.WarnSystemWarn: WarnSystemWarn,
     Action.VarAssign: VarAssign,
@@ -595,6 +599,10 @@ ACTIONS_MESSAGE_CONTEXT = [
     Action.AddChannelHeatpoints,
     Action.EmptyChannelHeat,
     Action.PunishUserWithMessage,
+    Action.ArchiveThread,
+    Action.LockThread,
+    Action.ArchiveAndLockThread,
+    Action.DeleteThread,
 ]
 
 ALLOWED_STATEMENTS = {


### PR DESCRIPTION
Hello,

This PR adds thread-related actions to Defender's Warden rules: `archive-thread: `, `lock-thread: `, `archive-and-lock-thread: ` and `delete-thread: `. They act according to context and take no arguments.

I couldn't test this PR because I haven't configured Defender for a long time, but I followed the same logic as for the other actions.

Have a nice day,
AAA3A

Closes #66 