### PR TITLE
Use `ctx.embed_colour()` in the Index cog

### DIFF
--- a/index/parser.py
+++ b/index/parser.py
@@ -41,8 +41,8 @@ class Repo:
                 continue
             self.cogs[cog_name] = Cog(cog_name, self, cog_raw)
 
-    def build_embed(self, *, prefix="[p]", is_owner=False):
-        em = discord.Embed(url=self.url, description=self.description, colour=discord.Colour.red())
+    def build_embed(self, *, prefix="[p]", colour: discord.Colour = discord.Colour.red(), is_owner=False):
+        em = discord.Embed(url=self.url, description=self.description, colour=colour)
         em.set_author(name=f"{self.name} by {', '.join(self.author)}")
         em.add_field(name="Type", value=self.rx_category, inline=True)
         if self.rx_branch:
@@ -74,7 +74,7 @@ class Cog:
         self.type = raw_data.get("type", "")
         self.repo = repo
 
-    def build_embed(self, *, prefix="[p]", is_owner=False):
+    def build_embed(self, *, prefix="[p]", colour: discord.Colour = discord.Colour.red(), is_owner=False):
         url = f"{self.repo.url}/{self.name}"
 
         if self.description:
@@ -109,12 +109,12 @@ class Cog:
         em.set_footer(text=f"{tags}")
         return em
 
-def build_embeds(repos_cogs, prefix="[p]", is_owner=False):
+def build_embeds(repos_cogs, prefix="[p]", colour: discord.Colour = discord.Colour.red(), is_owner=False):
     embeds = []
 
     for rc in repos_cogs:
         if isinstance(rc, (Repo, Cog)):
-            em = rc.build_embed(prefix=prefix, is_owner=is_owner)
+            em = rc.build_embed(prefix=prefix, colour=colour, is_owner=is_owner)
         else:
             raise TypeError("Unhandled type.")
         embeds.append(em)

--- a/index/parser.py
+++ b/index/parser.py
@@ -85,7 +85,7 @@ class Cog:
             author = ', '.join(self.author)
         else:
             author = self.repo.name
-        em = discord.Embed(url=url, description=description, colour=discord.Colour.red())
+        em = discord.Embed(url=url, description=description, colour=colour)
         em.set_author(name=f"{self.name} from {self.repo.name}")
         em.add_field(name="Type", value=self.repo.rx_category, inline=True)
         em.add_field(name="Author", value=author, inline=True)

--- a/index/views.py
+++ b/index/views.py
@@ -65,7 +65,7 @@ class IndexReposView(IndexView):
 
     async def show_repos(self):
         is_owner = await self.ctx.bot.is_owner(self.ctx.author) and self.ctx.bot.get_cog("Downloader")
-        self._embeds = build_embeds(self.repos, prefix=self.ctx.prefix, is_owner=is_owner)
+        self._embeds = build_embeds(self.repos, prefix=self.ctx.prefix, colour = await self.ctx.embed_colour(), is_owner=is_owner)
         if not is_owner:
             self.remove_item(self.install_repo)
         self._message = await self.ctx.send(embed=self._embeds[self._selected], view=self)
@@ -128,7 +128,7 @@ class IndexCogsView(IndexView):
             pass
         else:
             raise ValueError()
-        self._embeds = build_embeds(self.cogs, prefix=self.ctx.prefix, is_owner=is_owner)
+        self._embeds = build_embeds(self.cogs, prefix=self.ctx.prefix, colour = await self.ctx.embed_colour(), is_owner=is_owner)
         if not is_owner:
             self.remove_item(self.install_cog)
         if len(self._embeds) == 0:


### PR DESCRIPTION
As stated by the title, this PR makes the Index cog use the `ctx.embed_colour()`function wherever possible, instead of just using `discord.Colour.red()`. Tested and it works perfectly fine as far as I can tell.