### PR TITLE
[Defender] Support punctuation for MessageContainsWord

### DIFF
--- a/defender/core/warden/rule.py
+++ b/defender/core/warden/rule.py
@@ -538,7 +538,8 @@ class WardenRule:
 
         @checker(Condition.MessageContainsWord)
         async def message_contains_word(params: models.NonEmptyListStr):
-            message_words = message.content.lower().split()
+            # Split into words, allow for apostrophes
+            message_words = re.findall(r"\w+(?:'\w+)*", message.content.lower())
             for word in message_words:
                 for pattern in params.value:
                     if fnmatch.fnmatch(word, pattern.lower()):


### PR DESCRIPTION
Closes #53 

Haven't tested yet on the bot, but the regex split works in terminal