### PR TITLE
allow staff to be limited by CA

### DIFF
--- a/defender/core/events.py
+++ b/defender/core/events.py
@@ -240,7 +240,7 @@ class Events(MixinMeta, metaclass=CompositeMetaClass):  # type: ignore
                     log.warning("Unexpected error in InviteFilter", exc_info=e)
 
         ca_enabled = await self.config.guild(guild).ca_enabled()
-        if ca_enabled and not is_staff:
+        if ca_enabled:
             rank_ca = await self.config.guild(guild).ca_rank()
             if rank_ca and rank >= rank_ca:
                 try:


### PR DESCRIPTION
the reason of this is that by setting CA to also affect Rank 1 it will be overwritten by the check (I removed). This is problematic because it allows to set that up in the setup process, but at the end does not work (without knowing of the person that set that up, unless tested). In my setup I want to keep it activated also for mods, as it just deletes messages and so does not risk to punish in any way the staff.
Even though you may have done that to avoid a staff member to accidentally get banned, so there might be needed a warning message to be sent before configuring it that way (I think personally there is no need for that, as for example the Discord automod also affects mods (except admins and manage server perms) on default but does not make aware of this in any explicit way); 
and/or (I have't looked at the other modules yet) to make it the same everywhere. 
If you want I can take a look into it, just let me know