### PR TITLE
Allow checking recent messages in voice/stage channels

### DIFF
--- a/defender/commands/stafftools.py
+++ b/defender/commands/stafftools.py
@@ -114,7 +114,9 @@ class StaffTools(MixinMeta, metaclass=CompositeMetaClass):  # type: ignore
 
     @defmessagesgroup.command(name="channel")
     async def defmessagesgroupuserchannel(
-        self, ctx: commands.Context, channel: Union[discord.TextChannel, discord.Thread]
+        self,
+        ctx: commands.Context,
+        channel: Union[discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread],
     ):
         """Shows recent messages of a channel"""
         author = ctx.author

--- a/defender/defender.py
+++ b/defender/defender.py
@@ -218,7 +218,7 @@ class Defender(Commands, AutoModules, Events, commands.Cog, metaclass=CompositeM
                         _log.append(f"[{ts}]({channel})[{entry}] {content}")
                 else:
                     _log.append(f"[{ts}]({channel}) {content}")
-        elif isinstance(obj, (discord.TextChannel, discord.Thread)):
+        elif isinstance(obj, (discord.TextChannel, discord.VoiceChannel, discord.StageChannel, discord.Thread)):
             messages = df_cache.get_channel_messages(obj)
 
             async for m in AsyncIter(messages, steps=20):


### PR DESCRIPTION
Voice channels and stage channels have been messageable for a while but the `defender messages channel` command does not allow checking messages in them. From what I could tell, `on_message` should already cache messages in these so it should just be a matter of accepting them as input to this command.